### PR TITLE
remove config.json from gitignore so that jawsdb works on heroku

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,6 +108,3 @@ dist
 
 # VS Code settings
 .vscode
-
-# mysql config
-config/config.json

--- a/config/config.json
+++ b/config/config.json
@@ -1,0 +1,20 @@
+{
+  "development": {
+    "username": "root",
+    "password": null,
+    "database": "passport_demo",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
+  },
+  "test": {
+    "username": "root",
+    "password": null,
+    "database": "database_test",
+    "host": "127.0.0.1",
+    "dialect": "mysql"
+  },
+  "production": {
+    "use_env_variable": "JAWSDB_URL",
+    "dialect": "mysql"
+  }
+}


### PR DESCRIPTION
The config.json given in the starter files contains the required info for jawsdb (I think), so I removed the config.json from the gitignore and committed the starter file config.json.

Be sure to not add/commit the config.json file with your local mysql server password information.